### PR TITLE
Install translation files in a separate binary libfm-qt5-data, to avoid conflicts with futur soname changes.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -55,7 +55,8 @@ Architecture: any
 Multi-Arch: same
 Section: libs
 Depends: ${misc:Depends},
-         ${shlibs:Depends}
+         ${shlibs:Depends},
+         libfm-qt5-data
 Pre-Depends: ${misc:Pre-Depends}
 Description: file management support for pcmanfm-qt
  PCManFM-Qt is the Qt port of the LXDE file manager PCManFM.
@@ -93,3 +94,15 @@ Description: file management support for pcmanfm-qt (libfm-qt5 debug)
  manager for the lightweight desktop environment, LXQt.
  .
  This package contains debugging symbols for the shared libs.
+
+Package: libfm-qt5-data
+Architecture: all
+Depends: ${misc:Depends}
+Breaks: libfm-qt5-2 (<< 0.9.0+20150929-2)
+Conflicts: libfm-qt5-2 (<< 0.9.0+20150929-2)
+Description: file management support for pcmanfm-qt (core development files)
+ PCMan File Manager Qt (PCManFM-Qt) is an extremly fast, lightweight, yet
+ feature-rich file manager with tabbed browsing. It is the default file
+ manager for the lightweight desktop environment, LXQt.
+ .
+ This package contains translations for the library libfm-qt for pcmanfm-qt.

--- a/debian/libfm-qt5-2.install
+++ b/debian/libfm-qt5-2.install
@@ -1,2 +1,1 @@
 usr/lib/*/*.so.*
-usr/share/libfm-qt/translations/*

--- a/debian/libfm-qt5-data.install
+++ b/debian/libfm-qt5-data.install
@@ -1,0 +1,1 @@
+usr/share/libfm-qt/translations/*


### PR DESCRIPTION
I'm using a pull request to see if the changes are compliant with the package guidelines of the team.  I can push it to alioth if it's ok
The fix itself move the non .so files to a data binary. It will avoid conflict when the soname will change.